### PR TITLE
Use colon as a delimiter for splitting NIX_PATH

### DIFF
--- a/src/pypi2nix/cli.py
+++ b/src/pypi2nix/cli.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 
 import click
+from click.types import StringParamType
 
 import pypi2nix.overrides
 import pypi2nix.stage1
@@ -18,6 +19,10 @@ from pypi2nix.target_platform import PlatformGenerator
 from pypi2nix.utils import md5_sum_of_files_with_file_names
 
 
+class NixPathParamType(StringParamType):
+    envvar_list_splitter = ":"
+
+
 @click.command("pypi2nix")
 @click.option("--version", is_flag=True, help=u"Show version of pypi2nix")
 @click.option("-v", "--verbose", count=True)
@@ -27,6 +32,7 @@ from pypi2nix.utils import md5_sum_of_files_with_file_names
     envvar="NIX_PATH",
     multiple=True,
     default=None,
+    type=NixPathParamType(),
     help=u"Add a path to the Nix expression search path. This "
     u"option may be given multiple times. See the NIX_PATH "
     u"environment variable for information on the semantics "


### PR DESCRIPTION
Having a `NIX_PATH` with multiple values causes pypi2nix to pass it to Nix via *one* `-I` argument, which is not what Nix expects, thus resulting in errors like this:

```
warning: Nix search path entry '...' does not exist, ignoring
```

By default click splits environment variables on [whitespace](https://click.palletsprojects.com/en/7.x/options/#multiple-values-from-environment-values), rather than colon, which is the separator for `NIX_PATH`.

Splitting on colon is only done via the `File` and `Path` types in click, but they also either open the file or do checks whether the path exists.

These types are fine for things such as `PATH` or `LD_LIBRARY_PATH` and the likes, but `NIX_PATH` has a different format in that it allows bare paths and assignments (like eg. `nixpkgs=/some/path`).

So in order to fix this, I just added a new type that inherits from `StringParamType`, but correctly splits on colons.