### PR TITLE
cmd: Don't default to merging stdout with stderr

### DIFF
--- a/src/pypi2nix/utils.py
+++ b/src/pypi2nix/utils.py
@@ -129,15 +129,15 @@ def prefetch_git(url, rev=None):
 
 def prefetch_hg(url, rev=None, verbose=False):
     command = ["nix-prefetch-hg", url] + ([rev] if rev else [])
-    return_code, output = cmd(command, verbose)
+    return_code, output = cmd(command, verbose, stderr=subprocess.STDOUT)
     if return_code != 0:
         raise click.ClickException(
             " ".join(
                 [
                     "Could not fetch hg repository at {url}, returncode was {code}."
-                    "stdout:\n {stdout}"
+                    "output:\n {output}"
                 ]
-            ).format(url=url, code=return_code, stdout=output)
+            ).format(url=url, code=return_code, output=output)
         )
     HASH_PREFIX = "hash is "
     REV_PREFIX = "hg revision is "

--- a/src/pypi2nix/utils.py
+++ b/src/pypi2nix/utils.py
@@ -39,7 +39,7 @@ def safe(string):
     return string.replace('"', '\\"')
 
 
-def cmd(command, verbose=False, stderr=subprocess.STDOUT):
+def cmd(command, verbose=False, stderr=None):
 
     if isinstance(command, str):
         command = shlex.split(command)

--- a/src/pypi2nix/utils.py
+++ b/src/pypi2nix/utils.py
@@ -172,8 +172,10 @@ def escape_double_quotes(text):
 
 
 def prefetch_url(url, verbose=False):
-    returncode, output = cmd(["nix-prefetch-url", url], verbose=verbose)
-    return output.splitlines()[2]
+    returncode, output = cmd(
+        ["nix-prefetch-url", url], verbose=verbose, stderr=subprocess.DEVNULL
+    )
+    return output.rstrip()
 
 
 def download_file(url, filename, chunk_size=2048):


### PR DESCRIPTION
This is somewhat related to #280, because since the `NIX_PATH` got splitted in the wrong way, a
warning was emitted to `stdout`.

So when getting a JSON serialized output in [`Pip.default_environment()`](https://github.com/nix-community/pypi2nix/blob/a58028937eaa1d1aa04e7f362c505753456781bb/src/pypi2nix/pip.py#L128-L134), the output from the Nix (shell) command contained the warning at the top, which in turn results in a `JSONDecodeError`.

I think the default for this function should be to **not** merge `stderr`, which will eventually be printed to the TTY where the user can immediately see the warnings.