### PR TITLE
cli: Do not pick up NIX_PATH as default nix_path

### DIFF
--- a/src/pypi2nix/cli.py
+++ b/src/pypi2nix/cli.py
@@ -24,7 +24,6 @@ from pypi2nix.utils import md5_sum_of_files_with_file_names
 @click.option(
     "-I",
     "--nix-path",
-    envvar="NIX_PATH",
     multiple=True,
     default=None,
     help=u"Add a path to the Nix expression search path. This "


### PR DESCRIPTION
By default Nix merges the `-I` options with the values of `NIX_PATH`, which is exactly what is even [documented](https://github.com/nix-community/pypi2nix/blob/a58028937eaa1d1aa04e7f362c505753456781bb/src/pypi2nix/cli.py#L30-L34) for the `-I`/`--nix-path` option in pypi2nix, so we shouldn't actually base this option on the `NIX_PATH` environment variable.

This is a follow-up to #280, where I initially wanted to fix path splitting (so it's using colon instead of whitespace), but it's a bit more complicated, because `NIX_PATH` is splitted on colons but may also
contain URLs with a colon.

Closes: #280