### PR TITLE
overrides: Fix small typo in error message

### DIFF
--- a/src/pypi2nix/overrides.py
+++ b/src/pypi2nix/overrides.py
@@ -41,7 +41,7 @@ class OverridesUrl(object):
         sha_sum = output.strip()
         if len(sha_sum) != 52 or return_code != 0:
             raise click.ClickException(
-                "Could not determin hash for url %{url}s" % dict(url=self.url)
+                "Could not determine hash for url %{url}s" % dict(url=self.url)
             )
         return self.expression_template % dict(url=self.url, sha_string=sha_sum)
 


### PR DESCRIPTION
No biggie here, just noticed while reading the code.