### PR TITLE
utils: Fix duplicate newlines inserted by cmd()

### DIFF
--- a/src/pypi2nix/pip.py
+++ b/src/pypi2nix/pip.py
@@ -123,7 +123,8 @@ class Pip:
             BASE_NIX,
             nix_arguments=self.nix_arguments(),
         )
-        return "\n".join(map(lambda x: x.strip(), output.splitlines()))
+        lines = map(lambda x: x.strip(), output.splitlines())
+        return ("\n".join(lines) + "\n") if lines else ""
 
     def default_environment(self):
         output = self.nix.shell(

--- a/src/pypi2nix/utils.py
+++ b/src/pypi2nix/utils.py
@@ -64,7 +64,7 @@ def cmd(command, verbose=False, stderr=None):
         raise
     finally:
         p.communicate()
-    return p.returncode, "\n".join(out)
+    return p.returncode, "".join(out)
 
 
 def create_command_options(options, list_form=False):

--- a/unittests/test_util_cmd.py
+++ b/unittests/test_util_cmd.py
@@ -1,0 +1,6 @@
+from pypi2nix.utils import cmd
+
+
+def test_consistent_output():
+    exit_code, output = cmd(["seq", "5"])
+    assert output == "1\n2\n3\n4\n5\n"


### PR DESCRIPTION
Ideally we want to have the exact output that we get from the command we're running, but using [`readline()`](https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamReader.readline) on stdout of the process will **not** strip the newlines, so when we join them again using newlines, we suddenly end up with twice the amount of newlines.

I also added a small unit test case to make sure this won't break again in the future.