### PR TITLE
Fix newlines of cmd output

### DIFF
--- a/src/pypi2nix/pip/implementation.py
+++ b/src/pypi2nix/pip/implementation.py
@@ -143,7 +143,8 @@ class NixPip(Pip):
             BASE_NIX,
             nix_arguments=self.nix_arguments(),
         )
-        return "\n".join(map(lambda x: x.strip(), output.splitlines()))
+        lines = map(lambda x: x.strip(), output.splitlines())
+        return ("\n".join(lines) + "\n") if lines else ""
 
     def editable_sources_directory(self) -> str:
         return os.path.join(self.project_directory, "editable_sources")

--- a/src/pypi2nix/utils.py
+++ b/src/pypi2nix/utils.py
@@ -72,7 +72,7 @@ def cmd(
         raise
     finally:
         p.communicate()
-    return p.returncode, "\n".join(out)
+    return p.returncode, "".join(out)
 
 
 def create_command_options(options: Dict[str, NixOption],) -> List[str]:

--- a/unittests/pip/test_freeze.py
+++ b/unittests/pip/test_freeze.py
@@ -1,20 +1,25 @@
 import os.path
 
 from pypi2nix.pip.interface import Pip
+from pypi2nix.requirement_parser import RequirementParser
 from pypi2nix.requirement_set import RequirementSet
+from pypi2nix.target_platform import TargetPlatform
 
 from ..switches import nix
 
 
 @nix
-def test_freeze_on_empty_environment_yields_empty_file(pip):
+def test_freeze_on_empty_environment_yields_empty_file(pip: Pip):
     frozen_requirements = pip.freeze([])
-    assert not frozen_requirements
+    assert not frozen_requirements.strip()
 
 
 @nix
 def test_freeze_respects_additional_python_path(
-    pip: Pip, project_dir, current_platform, requirement_parser
+    pip: Pip,
+    project_dir: str,
+    current_platform: TargetPlatform,
+    requirement_parser: RequirementParser,
 ):
     prefix = os.path.join(project_dir, "custom-prefix")
     download_dir = os.path.join(project_dir, "download")

--- a/unittests/test_util_cmd.py
+++ b/unittests/test_util_cmd.py
@@ -1,0 +1,6 @@
+from pypi2nix.utils import cmd
+
+
+def test_consistent_output():
+    exit_code, output = cmd(["seq", "5"])
+    assert output == "1\n2\n3\n4\n5\n"

--- a/unittests/test_util_cmd.py
+++ b/unittests/test_util_cmd.py
@@ -1,6 +1,7 @@
+from pypi2nix.logger import Logger
 from pypi2nix.utils import cmd
 
 
-def test_consistent_output():
-    exit_code, output = cmd(["seq", "5"])
+def test_consistent_output(logger: Logger):
+    exit_code, output = cmd(["seq", "5"], logger=logger)
     assert output == "1\n2\n3\n4\n5\n"


### PR DESCRIPTION
This is basically #284.

Original PR text by @aszlig:

> Ideally we want to have the exact output that we get from the command we're running, but using readline() on stdout of the process will not strip the newlines, so when we join them again using newlines, we suddenly end up with twice the amount of newlines.
> 
> I also added a small unit test case to make sure this won't break again in the future.