### PR TITLE
Fix build for different channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,56 @@ sudo: required
 os:
 - linux
 env:
-  matrix:
-    - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
-    - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.09.tar.gz
+  global:
     - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz
+  matrix:
+    - TEST_FILE=aiohttp
+    - TEST_FILE=awscli_and_requests
+    - TEST_FILE=connexion
+    - TEST_FILE=empy
+    - TEST_FILE=flake8
+    - TEST_FILE=flake8_include_default_overrides
+    - TEST_FILE=flake8_mercurial
+    - TEST_FILE=flit
+    - TEST_FILE=ldap
+    - TEST_FILE=lektor
+    - TEST_FILE=pillow
+    - TEST_FILE=rss2email
+    - TEST_FILE=scipy
+    - TEST_FILE=serpy_0_1_1
+    - TEST_FILE=tornado
 install:
 - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true
 - nix-env -iA nixpkgs.nix-prefetch-git nixpkgs.nix-prefetch-hg
 script:
-- set -e
-- nix build
-- result/bin/pypi2nix --help
-- nix-shell --command 'pytest unittests/ --cov=src/'
-- nix-shell --command 'pytest integrationtests/'
+- nix-shell --command 'python -m unittest integrationtests/test_${TEST_FILE}.py'
+stages:
+- unittests
+- tests
+jobs:
+  include:
+  - stage: unittests
+  - name: nixos-19.03
+    os: linux
+    env:
+      - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
+    script:
+      - nix build
+      - result/bin/pypi2nix --version
+      - nix-shell --command 'pytest unittests/ --cov=src/'
+  - name: nixos-19.09
+    os: linux
+    env:
+      - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
+    script:
+      - nix build
+      - result/bin/pypi2nix --version
+      - nix-shell --command 'pytest unittests/ --cov=src/'
+  - name: nixos-unstable
+    os: linux
+    env:
+      - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz
+    script:
+      - nix build
+      - result/bin/pypi2nix --version
+      - nix-shell --command 'pytest unittests/ --cov=src/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ install:
 - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true
 - nix-env -iA nixpkgs.nix-prefetch-git nixpkgs.nix-prefetch-hg
 script:
+- set -e
 - nix build
 - result/bin/pypi2nix --help
-- nix-shell --command 'python -m unittest integrationtests/test_${TEST_FILE}.py'
 - nix-shell --command 'pytest unittests/ --cov=src/'
 - nix-shell --command 'pytest integrationtests/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
         - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz
     script:
     - nix build
+    - result/bin/pypi2nix --help
   - stage: build
     name: unittests
     os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ jobs:
     env:
       - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
     script:
+      - set -e
       - nix build
       - result/bin/pypi2nix --version
       - nix-shell --command 'pytest unittests/ --cov=src/'
@@ -44,6 +45,7 @@ jobs:
     env:
       - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
     script:
+      - set -e
       - nix build
       - result/bin/pypi2nix --version
       - nix-shell --command 'pytest unittests/ --cov=src/'
@@ -52,6 +54,7 @@ jobs:
     env:
       - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz
     script:
+      - set -e
       - nix build
       - result/bin/pypi2nix --version
       - nix-shell --command 'pytest unittests/ --cov=src/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,19 +31,15 @@ stages:
 jobs:
   include:
   - stage: build
-    name: build-19.03
+    name: build
     os: linux
     env:
-      - TEST_FILE=none
-      - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
-    script:
-    - nix build
-  - stage: build
-    name: build-nixos-unstable
-    os: linux
-    env:
-      - TEST_FILE=none
-      - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz
+      global:
+        - TEST_FILE=none
+      matrix:
+        - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
+        - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.09.tar.gz
+        - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz
     script:
     - nix build
   - stage: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,7 @@ sudo: required
 os:
 - linux
 env:
-  global:
-    - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz
   matrix:
-    - TEST_FILE=aiohttp
-    - TEST_FILE=awscli_and_requests
-    - TEST_FILE=connexion
-    - TEST_FILE=empy
-    - TEST_FILE=flake8
-    - TEST_FILE=flake8_include_default_overrides
-    - TEST_FILE=flake8_mercurial
-    - TEST_FILE=flit
-    - TEST_FILE=ldap
-    - TEST_FILE=lektor
-    - TEST_FILE=pillow
-    - TEST_FILE=rss2email
-    - TEST_FILE=scipy
-    - TEST_FILE=serpy_0_1_1
-    - TEST_FILE=tornado
     - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
     - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.09.tar.gz
     - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz
@@ -31,4 +14,5 @@ script:
 - nix build
 - result/bin/pypi2nix --help
 - nix-shell --command 'python -m unittest integrationtests/test_${TEST_FILE}.py'
-- nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz --command 'pytest unittests/ --cov=src/'
+- nix-shell --command 'pytest unittests/ --cov=src/'
+- nix-shell --command 'pytest integrationtests/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,34 +21,14 @@ env:
     - TEST_FILE=scipy
     - TEST_FILE=serpy_0_1_1
     - TEST_FILE=tornado
+    - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
+    - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.09.tar.gz
+    - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz
 install:
 - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true
 - nix-env -iA nixpkgs.nix-prefetch-git nixpkgs.nix-prefetch-hg
 script:
+- nix build
+- result/bin/pypi2nix --help
 - nix-shell --command 'python -m unittest integrationtests/test_${TEST_FILE}.py'
-stages:
-- build
-jobs:
-  include:
-  - stage: build
-    name: build
-    os: linux
-    env:
-      global:
-        - TEST_FILE=none
-      matrix:
-        - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz
-        - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.09.tar.gz
-        - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz
-    script:
-    - nix build
-    - result/bin/pypi2nix --help
-  - stage: build
-    name: unittests
-    os: linux
-    env:
-      - TEST_FILE=none
-    script:
-      - nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz --command 'pytest unittests/ --cov=src/'
-    after_success:
-      - nix-shell -p 'python3.pkgs.codecov' --command 'codecov'
+- nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz --command 'pytest unittests/ --cov=src/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ stages:
 jobs:
   include:
   - stage: unittests
-  - name: nixos-19.03
+    name: nixos-19.03
     os: linux
     env:
       - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.03.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ script:
 - nix-shell --command 'python -m unittest integrationtests/test_${TEST_FILE}.py'
 stages:
 - unittests
-- tests
 jobs:
   include:
   - stage: unittests

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,8 @@ in python.mkDerivation {
   src = nix-gitignore.gitignoreSource additionalIgnores ./.;
   outputs = [ "out" ];
   buildInputs = fromRequirementsFile ./requirements-dev.txt python.packages;
-  propagatedBuildInputs = fromRequirementsFile ./requirements.txt python.packages;
+  propagatedBuildInputs =
+    (fromRequirementsFile ./requirements.txt python.packages) ++ [pkgs.python3Packages.setuptools];
   doCheck = true;
   dontUseSetuptoolsShellHook = true;
   checkPhase = ''

--- a/requirements.nix
+++ b/requirements.nix
@@ -435,10 +435,10 @@ let
     };
 
     "importlib-metadata" = python.mkDerivation {
-      name = "importlib-metadata-0.22";
+      name = "importlib-metadata-0.23";
       src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/e5/9d/e9cffef4769606ec16ff83845655fa19d597d6d91ef49613eda9334135d7/importlib_metadata-0.22.tar.gz";
-        sha256 = "652234b6ab8f2506ae58e528b6fbcc668831d3cc758e1bc01ef438d328b68cdb";
+        url = "https://files.pythonhosted.org/packages/5d/44/636bcd15697791943e2dedda0dbe098d8530a38d113b202817133e0b06c0/importlib_metadata-0.23.tar.gz";
+        sha256 = "aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26";
 };
       doCheck = commonDoCheck;
       buildInputs = commonBuildInputs ++ [
@@ -649,15 +649,14 @@ let
     };
 
     "packaging" = python.mkDerivation {
-      name = "packaging-19.1";
+      name = "packaging-19.2";
       src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/8b/3a/5bfe64c319be5775ed7ea3bc1a8e5667e0d57a740cc0498ce03e032eaf93/packaging-19.1.tar.gz";
-        sha256 = "c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe";
+        url = "https://files.pythonhosted.org/packages/5a/2f/449ded84226d0e2fda8da9252e5ee7731bdf14cd338f622dfcd9934e0377/packaging-19.2.tar.gz";
+        sha256 = "28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47";
 };
       doCheck = commonDoCheck;
       buildInputs = commonBuildInputs ++ [ ];
       propagatedBuildInputs = [
-        self."attrs"
         self."pyparsing"
         self."six"
       ];
@@ -821,10 +820,10 @@ let
     };
 
     "pytest" = python.mkDerivation {
-      name = "pytest-5.1.2";
+      name = "pytest-5.1.3";
       src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/c3/66/228ce6dca2b4d2cd5f9c1244aca14e0b13c31e4dbdf39294e782a1c78f12/pytest-5.1.2.tar.gz";
-        sha256 = "b78fe2881323bd44fd9bd76e5317173d4316577e7b1cddebae9136a4495ec865";
+        url = "https://files.pythonhosted.org/packages/cd/a9/522f0830079931fee274ce63d8d31df59fc1c1d5896a5f07678c7ad6dc25/pytest-5.1.3.tar.gz";
+        sha256 = "cc6620b96bc667a0c8d4fa592a8c9c94178a1bd6cc799dbb057dfd9286d31a31";
 };
       doCheck = commonDoCheck;
       buildInputs = commonBuildInputs ++ [
@@ -1039,10 +1038,10 @@ let
     };
 
     "urllib3" = python.mkDerivation {
-      name = "urllib3-1.25.3";
+      name = "urllib3-1.25.6";
       src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/4c/13/2386233f7ee40aa8444b47f7463338f3cbdf00c316627558784e3f542f07/urllib3-1.25.3.tar.gz";
-        sha256 = "dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232";
+        url = "https://files.pythonhosted.org/packages/ff/44/29655168da441dff66de03952880c6e2d17b252836ff1aa4421fba556424/urllib3-1.25.6.tar.gz";
+        sha256 = "9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86";
 };
       doCheck = commonDoCheck;
       buildInputs = commonBuildInputs ++ [ ];

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -18,7 +18,7 @@ flake8-quotes==2.1.0
 flake8-unused-arguments==0.0.3
 flit==1.3
 idna==2.8
-importlib-metadata==0.22
+importlib-metadata==0.23
 intreehooks==1.0
 isort==4.3.21
 Jinja2==2.10.1
@@ -30,7 +30,7 @@ mypy==0.720
 mypy-extensions==0.4.1
 nix-prefetch-github==2.3.1
 orderdict==2019.4.13
-packaging==19.1
+packaging==19.2
 Parsley==1.3
 pdbpp==0.10.0
 pluggy==0.13.0
@@ -40,7 +40,7 @@ pycodestyle==2.5.0
 pyflakes==2.1.1
 Pygments==2.4.2
 pyparsing==2.4.2
-pytest==5.1.2
+pytest==5.1.3
 pytest-cov==2.7.1
 pytest-runner==5.1
 pytoml==0.1.21
@@ -52,7 +52,7 @@ testfixtures==6.10.0
 toml==0.10.0
 typed-ast==1.4.0
 typing-extensions==3.7.4
-urllib3==1.25.3
+urllib3==1.25.6
 values==2019.4.13
 wcwidth==0.1.7
 wmctrl==0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     Parsley
     requests
     setupcfg
+    setuptools
     toml
 include_package_data = true
 


### PR DESCRIPTION
This PR improves the tests run by travis CI and fixes an issue that was introduced due to a (accidental?) change to `nixpkgs` where setuptools is not included anymore in `propagatedBuildInputs` of pypi2nix.