### PR TITLE
Remove requests as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       - set -e
       - nix build
       - result/bin/pypi2nix --version
-      - nix-shell --command 'pytest unittests/ --cov=src/'
+      - nix-shell --command 'pytest unittests/'
   - name: nixos-19.09
     os: linux
     env:
@@ -48,7 +48,7 @@ jobs:
       - set -e
       - nix build
       - result/bin/pypi2nix --version
-      - nix-shell --command 'pytest unittests/ --cov=src/'
+      - nix-shell --command 'pytest unittests/'
   - name: nixos-unstable
     os: linux
     env:
@@ -57,4 +57,4 @@ jobs:
       - set -e
       - nix build
       - result/bin/pypi2nix --version
-      - nix-shell --command 'pytest unittests/ --cov=src/'
+      - nix-shell --command 'pytest unittests/'

--- a/conftest.py
+++ b/conftest.py
@@ -11,6 +11,7 @@ from pypi2nix.logger import StreamLogger
 from pypi2nix.nix import Nix
 from pypi2nix.package_source import PathSource
 from pypi2nix.pip.virtualenv import VirtualenvPip
+from pypi2nix.pypi import Pypi
 from pypi2nix.requirement_parser import RequirementParser
 from pypi2nix.requirement_set import RequirementSet
 from pypi2nix.sources import Sources
@@ -202,3 +203,8 @@ def sources_for_test_packages(data_directory):
             PathSource(os.path.join(data_directory, f"{package_name}-1.0.tar.gz")),
         )
     return sources
+
+
+@pytest.fixture
+def pypi(logger: Logger) -> Pypi:
+    return Pypi(logger=logger)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,13 +2,11 @@
 black
 flake8
 flake8-debugger
-flake8-isort
-flake8-quotes
 flake8-unused-arguments
 mypy
+isort
 
 # testing
-codecov
 pytest
 pytest-cov
 attrs

--- a/requirements.nix
+++ b/requirements.nix
@@ -193,25 +193,6 @@ let
       };
     };
 
-    "codecov" = python.mkDerivation {
-      name = "codecov-2.0.15";
-      src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/77/f2/9790ee0f04eb0571841aff5ba1709c7869e82aa2145a04a3d4770807ff50/codecov-2.0.15.tar.gz";
-        sha256 = "8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788";
-};
-      doCheck = commonDoCheck;
-      buildInputs = commonBuildInputs ++ [ ];
-      propagatedBuildInputs = [
-        self."coverage"
-        self."requests"
-      ];
-      meta = with pkgs.stdenv.lib; {
-        homepage = "http://github.com/codecov/codecov-python";
-        license = licenses.asl20;
-        description = "Hosted coverage reports for Github, Bitbucket and Gitlab";
-      };
-    };
-
     "coverage" = python.mkDerivation {
       name = "coverage-4.5.4";
       src = pkgs.fetchurl {
@@ -334,44 +315,6 @@ let
         homepage = "https://github.com/jbkahn/flake8-debugger";
         license = licenses.mit;
         description = "ipdb/pdb statement checker plugin for flake8";
-      };
-    };
-
-    "flake8-isort" = python.mkDerivation {
-      name = "flake8-isort-2.7.0";
-      src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/20/94/7f17d507ab8973922b98ef0c9ac32de88ac592c7a8367e528fe205e72f50/flake8-isort-2.7.0.tar.gz";
-        sha256 = "81a8495eefed3f2f63f26cd2d766c7b1191e923a15b9106e6233724056572c68";
-};
-      doCheck = commonDoCheck;
-      buildInputs = commonBuildInputs ++ [ ];
-      propagatedBuildInputs = [
-        self."flake8"
-        self."isort"
-        self."testfixtures"
-      ];
-      meta = with pkgs.stdenv.lib; {
-        homepage = "https://github.com/gforcada/flake8-isort";
-        license = licenses.gpl2;
-        description = "flake8 plugin that integrates isort .";
-      };
-    };
-
-    "flake8-quotes" = python.mkDerivation {
-      name = "flake8-quotes-2.1.0";
-      src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/18/f9/3323327526354c90fa0e6ff0f043133ae13dd2b89c5b638189cfd5fc9027/flake8-quotes-2.1.0.tar.gz";
-        sha256 = "5dbaf668887873f28346fb87943d6da2e4b9f77ce9f2169cff21764a0a4934ed";
-};
-      doCheck = commonDoCheck;
-      buildInputs = commonBuildInputs ++ [ ];
-      propagatedBuildInputs = [
-        self."flake8"
-      ];
-      meta = with pkgs.stdenv.lib; {
-        homepage = "http://github.com/zheller/flake8-quotes/";
-        license = licenses.mit;
-        description = "Flake8 lint for quotes.";
       };
     };
 
@@ -970,22 +913,6 @@ let
         homepage = "https://github.com/benjaminp/six";
         license = licenses.mit;
         description = "Python 2 and 3 compatibility utilities";
-      };
-    };
-
-    "testfixtures" = python.mkDerivation {
-      name = "testfixtures-6.10.0";
-      src = pkgs.fetchurl {
-        url = "https://files.pythonhosted.org/packages/71/e4/f00e137627758e7e47bf170783cc74dc97fc141fb94fbff38f1484eef837/testfixtures-6.10.0.tar.gz";
-        sha256 = "9d230c5c80746f9f86a16a1f751a5cf5d8e317d4cc48243a19fb180d22303bce";
-};
-      doCheck = commonDoCheck;
-      buildInputs = commonBuildInputs ++ [ ];
-      propagatedBuildInputs = [ ];
-      meta = with pkgs.stdenv.lib; {
-        homepage = "https://github.com/Simplistix/testfixtures";
-        license = licenses.mit;
-        description = "A collection of helpers and mock objects for unit tests and doc tests.";
       };
     };
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ click
 jinja2
 nix-prefetch-github
 parsley
-requests
 setupcfg
 toml
 packaging

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -5,7 +5,6 @@ black==19.3b0
 certifi==2019.9.11
 chardet==3.0.4
 Click==7.0
-codecov==2.0.15
 coverage==4.5.4
 docutils==0.15.2
 effect==0.12.0
@@ -13,8 +12,6 @@ entrypoints==0.3
 fancycompleter==0.8
 flake8==3.7.8
 flake8-debugger==3.1.0
-flake8-isort==2.7.0
-flake8-quotes==2.1.0
 flake8-unused-arguments==0.0.3
 flit==1.3
 idna==2.8
@@ -48,7 +45,6 @@ requests==2.22.0
 setupcfg==2019.4.13
 setuptools-scm==3.3.3
 six==1.12.0
-testfixtures==6.10.0
 toml==0.10.0
 typed-ast==1.4.0
 typing-extensions==3.7.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ install_requires =
     nix-prefetch-github
     packaging
     Parsley
-    requests
     setupcfg
     setuptools
     toml

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,16 +38,8 @@ ignore = E203, E266, E501, W503, F403, C901
 max-line-length = 79
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
-enabled_extensions = U10
+enabled_extensions = U10,T100
 
-# https://pypi.python.org/pypi/flake8-quotes
-inline-quotes = single
-multiline-quotes = '''
-docstring-quotes = '''
-unused-arguments-ignore-abstract-functions = True
-unused-arguments-ignore-stub-functions = True
-
-# https://pypi.python.org/pypi/isort
 [isort]
 line_length = 159
 force_single_line = True
@@ -57,40 +49,16 @@ known_first_party =
   pypi2nix
 
 [mypy]
-# Specify the target platform details in config, so your developers are
-# free to run mypy on Windows, Linux, or macOS and get consistent
-# results.
-# python version will be autodetected
-platform=linux
-
-# flake8-mypy expects the two following for sensible formatting
 show_column_numbers=True
 show_error_context=True
-
-# suppress errors about unsatisfied imports
 ignore_missing_imports=False
-
-# allow untyped calls as a consequence of the options above
 disallow_untyped_calls=False
-
-# allow returning Any as a consequence of the options above
 warn_return_any=True
-
-# treat Optional per PEP 484
 strict_optional=True
-
-# ensure all execution paths are returning
 warn_no_return=True
-
-# lint-style cleanliness for typing needs to be disabled; returns more errors
-# than the full run.
 warn_redundant_casts=True
 warn_unused_ignores=False
-
-# The following are off by default since they're too noisy.
-# Flip them on if you feel adventurous.
 disallow_untyped_defs=True
 check_untyped_defs=True
-
 mypy_path = mypy:src
 no_implicit_optional = True

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+args@{
+  pkgs ? import <nixpkgs> {},
+  ...
+}:
+
+let
+  default = import ./default.nix (args // { doCheck = true; });
+in
+default

--- a/src/pypi2nix/main.py
+++ b/src/pypi2nix/main.py
@@ -8,6 +8,7 @@ from pypi2nix.logger import StreamLogger
 from pypi2nix.memoize import memoize
 from pypi2nix.nix import Nix
 from pypi2nix.pip.implementation import NixPip
+from pypi2nix.pypi import Pypi
 from pypi2nix.requirement_parser import RequirementParser
 from pypi2nix.requirement_set import RequirementSet
 from pypi2nix.requirements_collector import RequirementsCollector
@@ -69,6 +70,7 @@ class Pypi2nix:
             sources=sources,
             logger=self.logger(),
             requirement_parser=self.requirement_parser(),
+            pypi=Pypi(logger=self.logger()),
         )
 
         packages_metadata = stage2.main(

--- a/src/pypi2nix/pypi.py
+++ b/src/pypi2nix/pypi.py
@@ -1,0 +1,92 @@
+import json
+import re
+from functools import lru_cache
+from http.client import HTTPException
+from typing import Optional
+from typing import Union
+from urllib.request import urlopen
+
+from attr import attrib
+from attr import attrs
+from packaging.version import LegacyVersion
+from packaging.version import Version
+from packaging.version import parse as parse_version
+
+from pypi2nix.logger import Logger
+from pypi2nix.pypi_package import PypiPackage
+from pypi2nix.pypi_release import PypiRelease
+from pypi2nix.pypi_release import ReleaseType
+
+
+@attrs(frozen=True)
+class Pypi:
+    _logger: Logger = attrib()
+    _index: str = attrib(default="https://pypi.org/pypi")
+
+    @lru_cache(maxsize=None)
+    def get_package(self, name: str) -> PypiPackage:
+        def get_release_type(package_type: str) -> ReleaseType:
+            if package_type == "sdist":
+                return ReleaseType.SOURCE
+            elif package_type == "bdist_wheel":
+                return ReleaseType.WHEEL
+            else:
+                self._logger.warning(
+                    f"Found unexpected `packagetype` entry for package `{name}`"
+                )
+                return ReleaseType.UNKNOWN
+
+        url = f"{self._index}/{name}/json"
+        try:
+            with urlopen(url) as response_buffer:
+                metadata = json.loads(response_buffer.read().decode("utf-8"))
+        except HTTPException:
+            raise PypiFailed(
+                f"Failed to download metadata information from `{url}`, given package name `{name}`"
+            )
+        releases = {
+            PypiRelease(
+                url=data["url"],
+                sha256_digest=data["digests"]["sha256"],
+                version=version,
+                type=get_release_type(data["packagetype"]),
+            )
+            for version, release_list in metadata["releases"].items()
+            for data in release_list
+        }
+
+        return PypiPackage(name=metadata["info"]["name"], releases=releases)
+
+    def get_source_release(self, name: str, version: str) -> Optional[PypiRelease]:
+        def version_tag_from_release_url(url: str) -> Union[Version, LegacyVersion]:
+            extension = "|".join(
+                map(re.escape, [".tar.gz", ".tar.bz2", ".tar", ".zip", ".tgz"])
+            )
+            regular_expression = r".*{name}-(?P<version>.*)(?P<extension>{extension})$".format(
+                name=re.escape(name), extension=extension
+            )
+            result = re.match(regular_expression, url)
+            if result:
+                return parse_version(result.group("version"))
+            else:
+                message = f"Could not guess version of package from url `{url}`"
+                self._logger.error(message)
+                raise PypiFailed(message)
+
+        package = self.get_package(name)
+        source_releases = filter(
+            lambda release: release.type == ReleaseType.SOURCE, package.releases
+        )
+        releases_for_version = filter(
+            lambda release: version_tag_from_release_url(release.url)
+            == parse_version(version),
+            source_releases,
+        )
+        for release in releases_for_version:
+            return release
+        else:
+            return None
+
+
+class PypiFailed(Exception):
+    pass

--- a/src/pypi2nix/pypi_package.py
+++ b/src/pypi2nix/pypi_package.py
@@ -1,0 +1,12 @@
+from typing import Set
+
+from attr import attrib
+from attr import attrs
+
+from pypi2nix.pypi_release import PypiRelease
+
+
+@attrs
+class PypiPackage:
+    name: str = attrib()
+    releases: Set[PypiRelease] = attrib()

--- a/src/pypi2nix/pypi_release.py
+++ b/src/pypi2nix/pypi_release.py
@@ -1,0 +1,20 @@
+from enum import Enum
+from enum import unique
+
+from attr import attrib
+from attr import attrs
+
+
+@unique
+class ReleaseType(Enum):
+    UNKNOWN = 0
+    SOURCE = 1
+    WHEEL = 2
+
+
+@attrs(frozen=True)
+class PypiRelease:
+    url: str = attrib()
+    sha256_digest: str = attrib()
+    version: str = attrib()
+    type: ReleaseType = attrib()

--- a/src/pypi2nix/pypi_release.py
+++ b/src/pypi2nix/pypi_release.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from enum import unique
+from typing import Optional
 
 from attr import attrib
 from attr import attrs
@@ -10,6 +11,20 @@ class ReleaseType(Enum):
     UNKNOWN = 0
     SOURCE = 1
     WHEEL = 2
+    EGG = 3
+    WIN_INSTALLER = 4
+
+
+_release_type_mapping = {
+    "sdist": ReleaseType.SOURCE,
+    "bdist_wheel": ReleaseType.WHEEL,
+    "bdist_egg": ReleaseType.EGG,
+    "bdist_wininst": ReleaseType.WIN_INSTALLER,
+}
+
+
+def get_release_type_by_packagetype(packagetype: str) -> Optional[ReleaseType]:
+    return _release_type_mapping.get(packagetype)
 
 
 @attrs(frozen=True)
@@ -18,3 +33,4 @@ class PypiRelease:
     sha256_digest: str = attrib()
     version: str = attrib()
     type: ReleaseType = attrib()
+    filename: str = attrib()

--- a/src/pypi2nix/utils.py
+++ b/src/pypi2nix/utils.py
@@ -9,7 +9,6 @@ from typing import Tuple
 from typing import Union
 
 import click
-import requests
 from nix_prefetch_github import nix_prefetch_github
 
 from pypi2nix.logger import Logger
@@ -170,12 +169,3 @@ def prefetch_url(url: str, logger: Logger) -> str:
         ["nix-prefetch-url", url], logger, stderr=subprocess.DEVNULL
     )
     return output.rstrip()
-
-
-def download_file(url: str, filename: str, chunk_size: int = 2048) -> None:
-    r = requests.get(url, stream=True, timeout=None)
-    r.raise_for_status()  # TODO: handle this nicer
-
-    with open(filename, "wb") as fd:
-        for chunk in r.iter_content(chunk_size):
-            fd.write(chunk)

--- a/src/pypi2nix/wheel.py
+++ b/src/pypi2nix/wheel.py
@@ -10,12 +10,10 @@ from typing import Optional
 from typing import Type
 
 import click
-import pkg_resources
 from packaging.utils import canonicalize_name
 
 from pypi2nix.license import find_license
 from pypi2nix.logger import Logger
-from pypi2nix.package_source import UrlSource
 from pypi2nix.requirement_parser import RequirementParser
 from pypi2nix.requirement_set import RequirementSet
 from pypi2nix.target_platform import TargetPlatform
@@ -194,58 +192,3 @@ def list_from_message(metadata: Message, key: str) -> Optional[List[str]]:
         return [str(item) if isinstance(item, Header) else item for item in maybe_value]
     else:
         return None
-
-
-def find_release(wheel: Wheel, wheel_data: Dict[str, Any], logger: Logger) -> UrlSource:
-    EXTENSIONS = [".tar.gz", ".tar.bz2", ".tar", ".zip", ".tgz"]
-
-    wheel_release = None
-
-    _releases = wheel_data["releases"].get(wheel.version, [])
-
-    # sometimes version in release list is not exact match and we need to use
-    # pkg_resources's parse_version function to detect which release list is
-    # correct
-    if not _releases:
-        for _version, _releases_tmp in wheel_data["releases"].items():
-            if pkg_resources.parse_version(
-                wheel.version
-            ) == pkg_resources.parse_version(_version):
-                _releases = _releases_tmp
-                break
-
-    # sometimes for some unknown reason release data is under other version.
-    # example: https://pypi.python.org/pypi/radiotherm/json
-    if not _releases:
-        _base_version = pkg_resources.parse_version(  # type: ignore
-            wheel.version
-        ).base_version
-        for _releases_tmp in wheel_data["releases"].values():
-            for _release_tmp in _releases_tmp:
-                for _ext in EXTENSIONS:
-                    if _release_tmp["filename"].endswith(wheel.version + _ext):
-                        _releases = [_release_tmp]
-                        break
-                    if _release_tmp["filename"].endswith(_base_version + _ext):
-                        _releases = [_release_tmp]
-                        break
-
-    # a release can come in different formats. formats we care about are
-    # listed in EXTENSIONS variable
-    for _release in _releases:
-        for _ext in EXTENSIONS:
-            if _release["filename"].endswith(_ext):
-                wheel_release = _release
-                break
-        if wheel_release:
-            break
-
-    if not wheel_release:
-        raise click.ClickException(
-            "Unable to find release for package {name} of version "
-            "{version}".format(name=wheel.name, version=wheel.version)
-        )
-
-    sha256_digest: str = wheel_release.get("digests", {}).get("sha256", None)
-    wheel_url: str = wheel_release["url"]
-    return UrlSource(wheel_url, logger, sha256_digest)

--- a/unittests/test_pypi.py
+++ b/unittests/test_pypi.py
@@ -48,3 +48,12 @@ def test_pypi_gets_correct_source_release_for_radiotherm_1_2(pypi):
         release.sha256_digest
         == "e8a70e0cf38f21170a3a43d5de62954aa38032dfff20adcdf79dd6c39734b8cc"
     )
+
+
+@nix
+def test_pypi_gets_correct_source_release_for_setuptools_1_6_0(pypi):
+    release = pypi.get_source_release("setuptools-scm", "1.6.0")
+    assert (
+        release.sha256_digest
+        == "c4f1b14e4fcc7dd69287a6c0b571c889dd4970559c7fa0512b2311f1513d86f4"
+    )

--- a/unittests/test_pypi.py
+++ b/unittests/test_pypi.py
@@ -1,0 +1,50 @@
+import pytest
+
+from pypi2nix.logger import Logger
+from pypi2nix.pypi import Pypi
+
+from .switches import nix
+
+
+@pytest.fixture
+def pypi(logger: Logger):
+    return Pypi(logger)
+
+
+@nix
+def test_pypi_get_package_returns_package_with_correct_name(pypi):
+    assert pypi.get_package("six").name == "six"
+
+
+@nix
+def test_pypi_get_package_returns_package_with_releases(pypi):
+    assert pypi.get_package("six").releases
+
+
+@nix
+def test_pypi_gets_correct_source_release_for_package_version_with_only_source_release(
+    pypi
+):
+    release = pypi.get_source_release("six", "0.9.0")
+    assert (
+        release.sha256_digest
+        == "14fd1ed3dd0e1a46cc53b8fc890b5a3b11737515aeb7f42c3af9f38e8d8975d7"
+    )
+
+
+@nix
+def test_pypi_gets_correct_source_release_for_package_with_multiple_release_types(pypi):
+    release = pypi.get_source_release("six", "1.12.0")
+    assert (
+        release.sha256_digest
+        == "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+    )
+
+
+@nix
+def test_pypi_gets_correct_source_release_for_radiotherm_1_2(pypi):
+    release = pypi.get_source_release("radiotherm", "1.2")
+    assert (
+        release.sha256_digest
+        == "e8a70e0cf38f21170a3a43d5de62954aa38032dfff20adcdf79dd6c39734b8cc"
+    )

--- a/unittests/test_wheel_builder.py
+++ b/unittests/test_wheel_builder.py
@@ -3,6 +3,7 @@ from typing import List
 import pytest
 
 from pypi2nix.logger import Logger
+from pypi2nix.pypi import Pypi
 from pypi2nix.requirement_parser import RequirementParser
 from pypi2nix.requirement_set import RequirementSet
 from pypi2nix.sources import Sources
@@ -21,13 +22,14 @@ def build_wheels(
     requirement_parser: RequirementParser,
     logger: Logger,
     sources_for_test_packages: Sources,
+    pypi: Pypi,
 ):
     def wrapper(requirement_lines: List[str]) -> List[Wheel]:
         requirements = RequirementSet(current_platform)
         for line in requirement_lines:
             requirements.add(requirement_parser.parse(line))
         wheel_paths = wheel_builder.build(requirements)
-        stage2 = Stage2(sources_for_test_packages, logger, requirement_parser)
+        stage2 = Stage2(sources_for_test_packages, logger, requirement_parser, pypi)
         return stage2.main(
             wheel_paths, current_platform, wheel_builder.additional_build_dependencies
         )


### PR DESCRIPTION
We need `requests` only in one place in our code.  We reimplement the code in question via `urllist.request.urlopen`.