### PR TITLE
Make requirement parser understand 'or' and 'and' statements with arity of n>=2

### DIFF
--- a/src/pypi2nix/requirement_parser_grammar.py
+++ b/src/pypi2nix/requirement_parser_grammar.py
@@ -45,8 +45,8 @@ class _RequirementParserGrammar:
         marker_var    = wsp* (env_var | python_str)
         marker_expr   = marker_var marker_op marker_var | wsp* '(' marker wsp* ')'
         marker_op     = version_cmp | (wsp* 'in') | (wsp* 'not' wsp+ 'in')
-        marker_and    = marker_expr wsp* 'and' marker_expr | marker_expr
-        marker_or     = marker_and wsp* 'or' marker_and | marker_and
+        marker_and    = marker_expr wsp* 'and' marker_and | marker_expr
+        marker_or     = marker_and wsp* 'or' marker_or | marker_and
         marker        = marker_or
         quoted_marker = ';' wsp* <marker>:m -> EnvironmentMarker(m)
         identifier_end = letterOrDigit | (('-' | '_' | '.' )* letterOrDigit)

--- a/unittests/regression/test_issue_363.py
+++ b/unittests/regression/test_issue_363.py
@@ -1,0 +1,20 @@
+"""Regression test for https://github.com/nix-community/pypi2nix/issues/363"""
+from pypi2nix.requirement_parser import RequirementParser
+
+
+def test_can_parse_enum_requirement_from_issue_363(
+    requirement_parser: RequirementParser
+):
+    requirement = requirement_parser.parse(
+        "enum34 (>=1.0.4) ; (python_version=='2.7' or python_version=='2.6' or python_version=='3.3')"
+    )
+    assert requirement.name() == "enum34"
+
+
+def test_can_parse_pyinotify_requirement_from_issue_363(
+    requirement_parser: RequirementParser
+):
+    requirement = requirement_parser.parse(
+        "pyinotify (>=0.9.6) ; (sys_platform!='win32' and sys_platform!='darwin' and sys_platform!='sunos5')"
+    )
+    assert requirement.name() == "pyinotify"


### PR DESCRIPTION
fixes #363