### PR TITLE
Refactor source distribution handling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ package_dir =
     pypi2nix = src/pypi2nix
     pypi2nix.pip = src/pypi2nix/pip
     pypi2nix.wheels = src/pypi2nix/wheels
+    pypi2nix.package = src/pypi2nix/package
 install_requires =
     attrs
     click

--- a/src/pypi2nix/package/interfaces.py
+++ b/src/pypi2nix/package/interfaces.py
@@ -1,0 +1,11 @@
+from abc import ABCMeta
+from abc import abstractmethod
+
+from pypi2nix.requirement_set import RequirementSet
+from pypi2nix.target_platform import TargetPlatform
+
+
+class HasBuildDependencies(metaclass=ABCMeta):
+    @abstractmethod
+    def build_dependencies(self, target_platform: TargetPlatform) -> RequirementSet:
+        pass

--- a/src/pypi2nix/package/pyproject.py
+++ b/src/pypi2nix/package/pyproject.py
@@ -1,0 +1,45 @@
+import toml
+
+from pypi2nix.logger import Logger
+from pypi2nix.requirement_parser import ParsingFailed
+from pypi2nix.requirement_parser import RequirementParser
+from pypi2nix.requirement_set import RequirementSet
+from pypi2nix.target_platform import TargetPlatform
+
+from .interfaces import HasBuildDependencies
+
+
+class PyprojectToml(HasBuildDependencies):
+    def __init__(
+        self,
+        name: str,
+        file_content: str,
+        logger: Logger,
+        requirement_parser: RequirementParser,
+    ) -> None:
+        self.pyproject_toml = toml.loads(file_content)
+        self.logger = logger
+        self.requirement_parser = requirement_parser
+        self.name = name
+
+    def build_dependencies(self, target_platform: TargetPlatform) -> RequirementSet:
+        requirement_set = RequirementSet(target_platform)
+        if self.pyproject_toml is not None:
+            for build_input in self.pyproject_toml.get("build-system", {}).get(
+                "requires", []
+            ):
+                try:
+                    requirement = self.requirement_parser.parse(build_input)
+                except ParsingFailed as e:
+                    self.logger.warning(
+                        "Failed to parse build dependency of `{name}`".format(
+                            name=self.name
+                        )
+                    )
+                    self.logger.warning(
+                        "Possible reason: `{reason}`".format(reason=e.reason)
+                    )
+                else:
+                    if requirement.applies_to_target(target_platform):
+                        requirement_set.add(requirement)
+        return requirement_set

--- a/src/pypi2nix/package/setupcfg.py
+++ b/src/pypi2nix/package/setupcfg.py
@@ -1,0 +1,46 @@
+from setuptools.config import read_configuration
+
+from pypi2nix.logger import Logger
+from pypi2nix.requirement_parser import ParsingFailed
+from pypi2nix.requirement_parser import RequirementParser
+from pypi2nix.requirement_set import RequirementSet
+from pypi2nix.target_platform import TargetPlatform
+
+from .interfaces import HasBuildDependencies
+
+
+class SetupCfg(HasBuildDependencies):
+    def __init__(
+        self,
+        name: str,
+        setup_cfg_path: str,
+        logger: Logger,
+        requirement_parser: RequirementParser,
+    ):
+        self.name = name
+        self.setup_cfg = read_configuration(setup_cfg_path)
+        self.logger = logger
+        self.requirement_parser = requirement_parser
+
+    def build_dependencies(self, target_platform: TargetPlatform) -> RequirementSet:
+        setup_requires = self.setup_cfg.get("options", {}).get("setup_requires")
+        requirements = RequirementSet(target_platform)
+        if isinstance(setup_requires, str):
+            requirements.add(self.requirement_parser.parse(setup_requires))
+        elif isinstance(setup_requires, list):
+            for requirement_string in setup_requires:
+                try:
+                    requirement = self.requirement_parser.parse(requirement_string)
+                except ParsingFailed as e:
+                    self.logger.warning(
+                        "Failed to parse build dependency of `{name}`".format(
+                            name=self.name
+                        )
+                    )
+                    self.logger.warning(
+                        "Possible reason: `{reason}`".format(reason=e.reason)
+                    )
+                else:
+                    if requirement.applies_to_target(target_platform):
+                        requirements.add(requirement)
+        return requirements

--- a/src/pypi2nix/source_distribution.py
+++ b/src/pypi2nix/source_distribution.py
@@ -56,14 +56,14 @@ class SourceDistribution(HasBuildDependencies):
                 extracted_files, archive
             )
             name: str = metadata.get("name")
+            if isinstance(name, Header):
+                raise DistributionNotDetected(
+                    "Could not parse source distribution metadata, name detection failed"
+                )
             pyproject_toml = source_distribution.get_pyproject_toml(
                 name, extracted_files, logger, requirement_parser
             )
             setup_cfg = source_distribution.get_setup_cfg(extracted_files)
-        if isinstance(name, Header):
-            raise DistributionNotDetected(
-                "Could not parse source distribution metadata, name detection failed"
-            )
         return source_distribution(
             name=name,
             pyproject_toml=pyproject_toml,

--- a/src/pypi2nix/stage1.py
+++ b/src/pypi2nix/stage1.py
@@ -84,7 +84,7 @@ class WheelBuilder:
             return detected_dependencies
         for distribution in uninspected_distributions:
             build_dependencies = distribution.build_dependencies(
-                self.target_platform, self.requirement_parser
+                self.target_platform
             ).filter(lambda requirement: requirement.name() not in [distribution.name])
             self.additional_build_dependencies[distribution.name] += build_dependencies
             detected_dependencies += build_dependencies
@@ -103,7 +103,9 @@ class WheelBuilder:
         for archive in archives:
             try:
                 distributions.append(
-                    SourceDistribution.from_archive(archive, self.logger)
+                    SourceDistribution.from_archive(
+                        archive, self.logger, requirement_parser=self.requirement_parser
+                    )
                 )
             except DistributionNotDetected:
                 continue

--- a/unittests/test_source_distribution.py
+++ b/unittests/test_source_distribution.py
@@ -5,22 +5,34 @@ import pytest
 
 from pypi2nix.archive import Archive
 from pypi2nix.logger import Logger
+from pypi2nix.requirement_parser import RequirementParser
 from pypi2nix.source_distribution import DistributionNotDetected
 from pypi2nix.source_distribution import SourceDistribution
+from pypi2nix.target_platform import TargetPlatform
 
 from .logger import get_logger_output
 from .switches import nix
 
 
 @pytest.fixture
-def source_distribution(six_source_distribution_archive, logger):
-    return SourceDistribution.from_archive(six_source_distribution_archive, logger)
+def source_distribution(
+    six_source_distribution_archive,
+    logger: Logger,
+    requirement_parser: RequirementParser,
+):
+    return SourceDistribution.from_archive(
+        six_source_distribution_archive, logger, requirement_parser=requirement_parser
+    )
 
 
 @pytest.fixture
-def flit_distribution(data_directory, logger):
+def flit_distribution(
+    data_directory, logger: Logger, requirement_parser: RequirementParser
+):
     archive = Archive(os.path.join(data_directory, "flit-1.3.tar.gz"))
-    return SourceDistribution.from_archive(archive, logger)
+    return SourceDistribution.from_archive(
+        archive, logger, requirement_parser=requirement_parser
+    )
 
 
 @nix
@@ -29,8 +41,12 @@ def test_from_archive_picks_up_on_name(source_distribution):
 
 
 @nix
-def test_that_a_source_distributions_name_is_canonicalized(logger):
-    distribution = SourceDistribution(name="NaMe_teSt", logger=logger)
+def test_that_a_source_distributions_name_is_canonicalized(
+    logger: Logger, requirement_parser: RequirementParser
+):
+    distribution = SourceDistribution(
+        name="NaMe_teSt", logger=logger, requirement_parser=requirement_parser
+    )
     assert distribution.name == "name-test"
 
 
@@ -46,63 +62,78 @@ def test_that_flit_pyproject_toml_is_recognized(flit_distribution):
 
 @nix
 def test_that_flit_build_dependencies_contains_requests(
-    flit_distribution, current_platform, requirement_parser
+    flit_distribution: SourceDistribution, current_platform: TargetPlatform
 ):
-    assert "requests" in flit_distribution.build_dependencies(
-        current_platform, requirement_parser
-    )
+    assert "requests" in flit_distribution.build_dependencies(current_platform)
 
 
 @nix
 def test_that_we_can_generate_objects_from_source_archives(
-    source_distribution_archive, logger
+    source_distribution_archive, logger: Logger, requirement_parser: RequirementParser,
 ):
-    SourceDistribution.from_archive(source_distribution_archive, logger)
+    SourceDistribution.from_archive(
+        source_distribution_archive, logger, requirement_parser=requirement_parser
+    )
 
 
 @nix
 def test_that_we_can_detect_setup_requirements_for_setup_cfg_projects(
-    distribution_archive_for_jsonschema, current_platform, logger, requirement_parser
+    distribution_archive_for_jsonschema,
+    current_platform,
+    logger: Logger,
+    requirement_parser: RequirementParser,
 ):
     distribution = SourceDistribution.from_archive(
-        distribution_archive_for_jsonschema, logger
+        distribution_archive_for_jsonschema,
+        logger,
+        requirement_parser=requirement_parser,
     )
-    assert "setuptools-scm" in distribution.build_dependencies(
-        current_platform, requirement_parser
-    )
+    assert "setuptools-scm" in distribution.build_dependencies(current_platform)
 
 
 def test_that_trying_to_create_source_distribution_from_random_zip_throws(
-    test_zip_path, logger
+    test_zip_path, logger: Logger, requirement_parser: RequirementParser
 ):
     archive = Archive(path=test_zip_path)
     with pytest.raises(DistributionNotDetected):
-        SourceDistribution.from_archive(archive, logger)
+        SourceDistribution.from_archive(
+            archive, logger, requirement_parser=requirement_parser,
+        )
 
 
 def test_build_dependencies_for_invalid_deps_logs_warning(
-    data_directory, current_platform, logger: Logger, requirement_parser
+    data_directory,
+    current_platform,
+    logger: Logger,
+    requirement_parser: RequirementParser,
 ):
     spacy_distribution_path = os.path.join(data_directory, "spacy-2.1.0.tar.gz")
     archive = Archive(spacy_distribution_path)
 
-    dist = SourceDistribution.from_archive(archive, logger)
+    dist = SourceDistribution.from_archive(
+        archive, logger, requirement_parser=requirement_parser
+    )
 
     assert "WARNING:" not in get_logger_output(logger)
-    dist.build_dependencies(current_platform, requirement_parser)
+    dist.build_dependencies(current_platform)
     assert "WARNING:" in get_logger_output(logger)
 
 
 def test_invalid_build_dependencies_for_setupcfg_package_logs_warning(
-    data_directory, current_platform, logger, requirement_parser
+    data_directory,
+    current_platform,
+    logger: Logger,
+    requirement_parser: RequirementParser,
 ):
     distribution_path = os.path.join(
         data_directory, "setupcfg-package", "setupcfg-package.tar.gz"
     )
     archive = Archive(distribution_path)
 
-    dist = SourceDistribution.from_archive(archive, logger)
+    dist = SourceDistribution.from_archive(
+        archive, logger, requirement_parser=requirement_parser
+    )
 
     assert "WARNING:" not in get_logger_output(logger)
-    dist.build_dependencies(current_platform, requirement_parser)
+    dist.build_dependencies(current_platform)
     assert "WARNING:" in get_logger_output(logger)


### PR DESCRIPTION
We want to prepare for dealing with #368 .  This PR tries to separate the logic for inspecting `pyproject.toml` and `setup.cfg` from dealing with source distribution formats.